### PR TITLE
Fix reproducible task-image builds for V8, SpiderMonkey, and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,12 @@ uv run harness/grade.py --project linux --target-dir harness/output/linux/codex/
 Summary CSVs are written to `<timestamp_dir>/summary` unless `--out-dir` is set. Linux latest validation uses per-CVE images from `hwiwonlee/linux.x86_64.latest:<instance_id>`; build local copies with:
 
 ```sh
-python projects/linux/build_images.py --mode latest --linux-ref origin/master -j 4
+python projects/linux/build_images.py --mode latest -j 4
 ```
+
+The default latest snapshot is pinned to Linux commit
+`d2c9a99135da931377240942d44f3dea104cedb8`. Pass `--linux-ref` only when
+intentionally building a different snapshot.
 
 SpiderMonkey fixed images use `hwiwonlee/sm.x86_64.fixed:<issue_id>`. To build
 a local replacement for a tag, run:

--- a/base/linux/Dockerfile.latest
+++ b/base/linux/Dockerfile.latest
@@ -3,11 +3,12 @@
 # Build with a validated Linux CVE directory as the Docker context:
 #
 #   docker build -f base/linux/Dockerfile.latest \
+#     --platform linux/amd64 \
 #     --build-arg LINUX_REF=d2c9a99135da931377240942d44f3dea104cedb8 \
 #     -t hwiwonlee/linux.x86_64.latest:CVE-2022-0185 \
 #     /path/to/linux/CVE-2022-0185
 #
-# The context format intentionally matches the 89 validated Linux leaves:
+# The context format intentionally matches the validated Linux leaves:
 # secb_config.json, build.sh, secb.sh, init.sh, and config/ are copied exactly
 # like Dockerfile/Dockerfile.fixed. Layers before the per-CVE COPY steps are
 # shared through Docker's build cache across every latest leaf.
@@ -48,10 +49,13 @@ RUN set -eux; \
     if [[ "$ref" == origin/* ]]; then \
     branch="${ref#origin/}"; \
     git -C /src/linux.git fetch origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"; \
-    elif ! git -C /src/linux.git rev-parse --verify -q "${ref}^{commit}" >/dev/null; then \
-    git -C /src/linux.git fetch origin "$ref"; \
-    fi; \
+    latest_commit="$(git -C /src/linux.git rev-parse "refs/remotes/origin/${branch}^{commit}")"; \
+    elif git -C /src/linux.git rev-parse --verify -q "${ref}^{commit}" >/dev/null; then \
     latest_commit="$(git -C /src/linux.git rev-parse "${ref}^{commit}")"; \
+    else \
+    git -C /src/linux.git fetch origin "$ref"; \
+    latest_commit="$(git -C /src/linux.git rev-parse "FETCH_HEAD^{commit}")"; \
+    fi; \
     rm -rf /src/linux; \
     git -C /src/linux.git worktree prune; \
     git -C /src/linux.git worktree add --detach /src/linux "$latest_commit"; \

--- a/base/linux/Dockerfile.latest
+++ b/base/linux/Dockerfile.latest
@@ -1,9 +1,9 @@
-# Per-CVE upstream-latest Linux kernel image.
+# Per-CVE pinned latest-snapshot Linux kernel image.
 #
 # Build with a validated Linux CVE directory as the Docker context:
 #
 #   docker build -f base/linux/Dockerfile.latest \
-#     --build-arg LINUX_REF=origin/master \
+#     --build-arg LINUX_REF=d2c9a99135da931377240942d44f3dea104cedb8 \
 #     -t hwiwonlee/linux.x86_64.latest:CVE-2022-0185 \
 #     /path/to/linux/CVE-2022-0185
 #
@@ -16,7 +16,7 @@ FROM hwiwonlee/linux.base:latest
 
 SHELL ["/bin/bash", "-lc"]
 
-ARG LINUX_REF=origin/master
+ARG LINUX_REF=d2c9a99135da931377240942d44f3dea104cedb8
 # Set by build_latest_images.sh for moving refs such as origin/master so Docker
 # does not incorrectly reuse an old fetched commit.
 ARG LINUX_REF_CACHE_BUST=manual
@@ -48,12 +48,10 @@ RUN set -eux; \
     if [[ "$ref" == origin/* ]]; then \
     branch="${ref#origin/}"; \
     git -C /src/linux.git fetch origin "+refs/heads/${branch}:refs/remotes/origin/${branch}"; \
-    elif git -C /src/linux.git rev-parse --verify -q "${ref}^{commit}" >/dev/null; then \
-    :; \
-    else \
-    git -C /src/linux.git fetch origin "$ref" || true; \
+    elif ! git -C /src/linux.git rev-parse --verify -q "${ref}^{commit}" >/dev/null; then \
+    git -C /src/linux.git fetch origin "$ref"; \
     fi; \
-    latest_commit="$(git -C /src/linux.git rev-parse "${ref}^{commit}" 2>/dev/null || git -C /src/linux.git rev-parse FETCH_HEAD^{commit})"; \
+    latest_commit="$(git -C /src/linux.git rev-parse "${ref}^{commit}")"; \
     rm -rf /src/linux; \
     git -C /src/linux.git worktree prune; \
     git -C /src/linux.git worktree add --detach /src/linux "$latest_commit"; \

--- a/base/linux/build_latest_images.sh
+++ b/base/linux/build_latest_images.sh
@@ -13,6 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 IMAGE_REPO="${IMAGE_REPO:-hwiwonlee/linux.x86_64.latest}"
+IMAGE_PLATFORM="${IMAGE_PLATFORM:-linux/amd64}"
 LINUX_REF="${LINUX_REF:-d2c9a99135da931377240942d44f3dea104cedb8}"
 LINUX_REF_CACHE_BUST="${LINUX_REF_CACHE_BUST:-}"
 KBUILD_JOBS="${KBUILD_JOBS:-}"
@@ -40,6 +41,7 @@ Options:
                        UTC timestamp for origin/* refs.
   --kbuild-jobs N      KBUILD_JOBS build arg passed to the kernel build.
   --image-repo REPO    Image repository (default: hwiwonlee/linux.x86_64.latest).
+  --platform PLATFORM  Docker target platform (default: linux/amd64).
   --no-cache           Pass --no-cache to docker build.
   --push               Push each leaf after successful build.
   --skip-existing      Skip tags already present locally.
@@ -47,7 +49,7 @@ Options:
 
 Environment equivalents:
   BENCHMARK_DIR, PARALLEL, LINUX_REF, LINUX_REF_CACHE_BUST, KBUILD_JOBS,
-  IMAGE_REPO, NO_CACHE=1, PUSH=1, SKIP_EXISTING=1
+  IMAGE_REPO, IMAGE_PLATFORM, NO_CACHE=1, PUSH=1, SKIP_EXISTING=1
 
 Examples:
   base/linux/build_latest_images.sh --benchmark-dir /home/xeon/work/benchmark/linux -j 2
@@ -88,6 +90,11 @@ while [[ $# -gt 0 ]]; do
     --image-repo)
       [[ $# -ge 2 ]] || die "$1 requires a value"
       IMAGE_REPO="$2"
+      shift 2
+      ;;
+    --platform)
+      [[ $# -ge 2 ]] || die "$1 requires a value"
+      IMAGE_PLATFORM="$2"
       shift 2
       ;;
     --no-cache)
@@ -139,11 +146,17 @@ BENCHMARK_DIR="$(cd "$BENCHMARK_DIR" && pwd)"
 DOCKERFILE="$SCRIPT_DIR/Dockerfile.latest"
 [[ -f "$DOCKERFILE" ]] || die "missing Dockerfile.latest: $DOCKERFILE"
 
+INSTANCES=()
 if [[ $# -gt 0 ]]; then
-  mapfile -t INSTANCES < <(printf '%s\n' "$@" | sort -u)
+  while IFS= read -r id; do
+    INSTANCES+=("$id")
+  done < <(printf '%s\n' "$@" | sort -u)
 else
-  mapfile -t INSTANCES < <(
-    find "$BENCHMARK_DIR" -maxdepth 1 -type d -name 'CVE-*' -printf '%f\n' | sort -u
+  while IFS= read -r id; do
+    INSTANCES+=("$id")
+  done < <(
+    find "$BENCHMARK_DIR" -maxdepth 1 -type d -name 'CVE-*' \
+      -exec basename {} \; | sort -u
   )
 fi
 [[ "${#INSTANCES[@]}" -gt 0 ]] || die "no instances selected"
@@ -173,6 +186,7 @@ build_one() {
   local log_file="$BUILD_LOG_DIR/$id.log"
   local -a cmd=(
     docker build
+    --platform "$IMAGE_PLATFORM"
     -f "$DOCKERFILE"
     -t "$tag"
     --build-arg "LINUX_REF=$LINUX_REF"
@@ -204,7 +218,7 @@ build_one() {
   return 1
 }
 
-export BENCHMARK_DIR DOCKERFILE IMAGE_REPO
+export BENCHMARK_DIR DOCKERFILE IMAGE_REPO IMAGE_PLATFORM
 export LINUX_REF LINUX_REF_CACHE_BUST KBUILD_JOBS
 export NO_CACHE PUSH SKIP_EXISTING BUILD_LOG_DIR SCRIPT_DIR
 export -f log die validate_instance build_one
@@ -217,6 +231,7 @@ log "selected ${#INSTANCES[@]} instance(s)"
 log "benchmark dir: $BENCHMARK_DIR"
 log "logs: $BUILD_LOG_DIR"
 log "image repo: $IMAGE_REPO"
+log "platform: $IMAGE_PLATFORM"
 log "linux ref: $LINUX_REF"
 [[ -n "$LINUX_REF_CACHE_BUST" ]] && log "linux ref cache-bust: $LINUX_REF_CACHE_BUST"
 log "parallel: $PARALLEL"

--- a/base/linux/build_latest_images.sh
+++ b/base/linux/build_latest_images.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 IMAGE_REPO="${IMAGE_REPO:-hwiwonlee/linux.x86_64.latest}"
-LINUX_REF="${LINUX_REF:-origin/master}"
+LINUX_REF="${LINUX_REF:-d2c9a99135da931377240942d44f3dea104cedb8}"
 LINUX_REF_CACHE_BUST="${LINUX_REF_CACHE_BUST:-}"
 KBUILD_JOBS="${KBUILD_JOBS:-}"
 PARALLEL="${PARALLEL:-1}"
@@ -33,7 +33,8 @@ Options:
   --benchmark-dir DIR  Linux benchmark root containing CVE-* directories.
                        Defaults to ./projects/linux if present, else ~/work/benchmark/linux.
   -j, --parallel N     Number of docker builds to run concurrently (default: 1).
-  --linux-ref REF      Linux ref/commit to build (default: origin/master).
+  --linux-ref REF      Linux ref/commit to build.
+                       Default: d2c9a99135da931377240942d44f3dea104cedb8.
   --linux-ref-cache-bust VALUE
                        Cache-bust value for moving refs. Defaults to current
                        UTC timestamp for origin/* refs.

--- a/base/sm/Dockerfile
+++ b/base/sm/Dockerfile
@@ -115,11 +115,16 @@ WORKDIR $SRC
 # path the instance Dockerfiles use). gecko-dev is fetched as a second
 # remote without --filter so legacy `git checkout <gecko-dev sha>` doesn't
 # need to lazy-fetch from a partial-clone promisor that points elsewhere.
+ARG FIREFOX_REF=dab03896ede1413be148884e054b311767bcf1a0
+ARG GECKO_DEV_REF=5836a062726f715fda621338a17b51aff30d0a8c
 RUN git clone --filter=blob:none --single-branch --branch main https://github.com/mozilla-firefox/firefox.git $SRC/gecko-dev && \
     cd $SRC/gecko-dev && \
     git remote rename origin firefox && \
     git remote add gecko-dev https://github.com/mozilla/gecko-dev.git && \
-    git fetch gecko-dev master
+    git fetch firefox "$FIREFOX_REF" && \
+    git checkout --detach "$FIREFOX_REF" && \
+    git fetch gecko-dev "$GECKO_DEV_REF:refs/remotes/gecko-dev/master" && \
+    git clean -xdf
 
 WORKDIR $SRC/gecko-dev
 

--- a/base/sm/Dockerfile.latest
+++ b/base/sm/Dockerfile.latest
@@ -10,15 +10,14 @@ ENV PATH="/root/.mozbuild/clang/bin:/root/.cargo/bin:/root/.mozbuild/cbindgen:$P
 
 WORKDIR $SRC/gecko-dev
 
-# The base image tracks firefox/main in $SRC/gecko-dev and carries gecko-dev as
-# a secondary remote for older instance builds. The latest image defaults to
-# firefox/main but accepts any locally resolvable ref or fetched commit.
-ARG SM_REF=firefox/main
+# The base image carries firefox and gecko-dev remotes for instance builds.
+# Keep the benchmark's latest snapshot on the exact evaluated Firefox commit.
+ARG SM_REF=0fa53bd1ab44248075642aef08edcc34fac551aa
 
 RUN set -eux; \
-    git fetch firefox main; \
-    git fetch gecko-dev master; \
-    git checkout --detach "$SM_REF"
+    git fetch firefox "$SM_REF"; \
+    git checkout --detach "$SM_REF"; \
+    git clean -xdf
 
 RUN set -eux; \
     rm -f mozconfig .mozconfig; \

--- a/base/sm/Dockerfile.latest
+++ b/base/sm/Dockerfile.latest
@@ -29,6 +29,8 @@ ac_add_options --enable-debug
 ac_add_options --enable-debug-symbols
 ac_add_options --enable-application=js
 ac_add_options --disable-bootstrap
+ac_add_options --host=x86_64-unknown-linux-gnu
+ac_add_options --target=x86_64-unknown-linux-gnu
 mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-debug-asan
 EOF
 RUN ./mach build
@@ -40,6 +42,8 @@ ac_add_options --enable-optimize
 ac_add_options --disable-debug
 ac_add_options --enable-application=js
 ac_add_options --disable-bootstrap
+ac_add_options --host=x86_64-unknown-linux-gnu
+ac_add_options --target=x86_64-unknown-linux-gnu
 mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/obj-release
 EOF
 RUN ./mach build

--- a/base/v8/Dockerfile
+++ b/base/v8/Dockerfile
@@ -56,8 +56,11 @@ ENV LC_ALL=en_US.UTF-8
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 # ---- Install depot_tools (provides gclient, gn, autoninja, fetch, etc.) ----
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools
+ARG DEPOT_TOOLS_REF=1ea94929dc77e2b9b9b9e2ede3bbc0f39c10ebc9
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools && \
+    git -C /opt/depot_tools checkout --detach "$DEPOT_TOOLS_REF"
 ENV PATH="/opt/depot_tools:$PATH"
+ENV DEPOT_TOOLS_UPDATE=0
 
 # Make git fetches more robust in Docker (big repos + googlesource mirrors)
 ENV GIT_HTTP_VERSION=HTTP/1.1
@@ -66,7 +69,11 @@ ENV GIT_HTTP_VERSION=HTTP/1.1
 WORKDIR $SRC
 
 # fetch v8: creates .gclient in $SRC and clones source into $SRC/src
-RUN fetch v8
+ARG V8_BASE_REF=dbb6746443d3db53c5067d4a846a1dd192844558
+RUN fetch v8 && \
+    git -C "$SRC/v8" fetch origin "$V8_BASE_REF" && \
+    git -C "$SRC/v8" checkout --detach "$V8_BASE_REF" && \
+    git -C "$SRC/v8" clean -xdf
 
 WORKDIR $SRC/v8
 

--- a/base/v8/Dockerfile
+++ b/base/v8/Dockerfile
@@ -57,10 +57,11 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 # ---- Install depot_tools (provides gclient, gn, autoninja, fetch, etc.) ----
 ARG DEPOT_TOOLS_REF=1ea94929dc77e2b9b9b9e2ede3bbc0f39c10ebc9
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools && \
-    git -C /opt/depot_tools checkout --detach "$DEPOT_TOOLS_REF"
-ENV PATH="/opt/depot_tools:$PATH"
 ENV DEPOT_TOOLS_UPDATE=0
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools && \
+    git -C /opt/depot_tools checkout --detach "$DEPOT_TOOLS_REF" && \
+    /opt/depot_tools/ensure_bootstrap
+ENV PATH="/opt/depot_tools:$PATH"
 
 # Make git fetches more robust in Docker (big repos + googlesource mirrors)
 ENV GIT_HTTP_VERSION=HTTP/1.1
@@ -68,7 +69,7 @@ ENV GIT_HTTP_VERSION=HTTP/1.1
 # ---- Fetch V8 source ----
 WORKDIR $SRC
 
-# fetch v8: creates .gclient in $SRC and clones source into $SRC/src
+# fetch v8: creates .gclient in $SRC and clones source into $SRC/v8
 ARG V8_BASE_REF=dbb6746443d3db53c5067d4a846a1dd192844558
 RUN fetch v8 && \
     git -C "$SRC/v8" fetch origin "$V8_BASE_REF" && \

--- a/base/v8/Dockerfile.latest
+++ b/base/v8/Dockerfile.latest
@@ -57,10 +57,11 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 # ---- Install depot_tools (provides gclient, gn, autoninja, fetch, etc.) ----
 ARG DEPOT_TOOLS_REF=1ea94929dc77e2b9b9b9e2ede3bbc0f39c10ebc9
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools && \
-    git -C /opt/depot_tools checkout --detach "$DEPOT_TOOLS_REF"
-ENV PATH="/opt/depot_tools:$PATH"
 ENV DEPOT_TOOLS_UPDATE=0
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools && \
+    git -C /opt/depot_tools checkout --detach "$DEPOT_TOOLS_REF" && \
+    /opt/depot_tools/ensure_bootstrap
+ENV PATH="/opt/depot_tools:$PATH"
 
 # Make git fetches more robust in Docker (big repos + googlesource mirrors)
 ENV GIT_HTTP_VERSION=HTTP/1.1
@@ -68,7 +69,7 @@ ENV GIT_HTTP_VERSION=HTTP/1.1
 # ---- Fetch V8 source ----
 WORKDIR $SRC
 
-# fetch v8: creates .gclient in $SRC and clones source into $SRC/src
+# fetch v8: creates .gclient in $SRC and clones source into $SRC/v8
 ARG V8_REF=69d9eb7057f4137d3e6c7ff28e0b103c7e8a7727
 RUN fetch v8 && \
     git -C "$SRC/v8" fetch origin "$V8_REF" && \

--- a/base/v8/Dockerfile.latest
+++ b/base/v8/Dockerfile.latest
@@ -56,8 +56,11 @@ ENV LC_ALL=en_US.UTF-8
 RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 # ---- Install depot_tools (provides gclient, gn, autoninja, fetch, etc.) ----
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools
+ARG DEPOT_TOOLS_REF=1ea94929dc77e2b9b9b9e2ede3bbc0f39c10ebc9
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /opt/depot_tools && \
+    git -C /opt/depot_tools checkout --detach "$DEPOT_TOOLS_REF"
 ENV PATH="/opt/depot_tools:$PATH"
+ENV DEPOT_TOOLS_UPDATE=0
 
 # Make git fetches more robust in Docker (big repos + googlesource mirrors)
 ENV GIT_HTTP_VERSION=HTTP/1.1
@@ -66,7 +69,11 @@ ENV GIT_HTTP_VERSION=HTTP/1.1
 WORKDIR $SRC
 
 # fetch v8: creates .gclient in $SRC and clones source into $SRC/src
-RUN fetch v8
+ARG V8_REF=69d9eb7057f4137d3e6c7ff28e0b103c7e8a7727
+RUN fetch v8 && \
+    git -C "$SRC/v8" fetch origin "$V8_REF" && \
+    git -C "$SRC/v8" checkout --detach "$V8_REF" && \
+    git -C "$SRC/v8" clean -xdf
 
 WORKDIR $SRC/v8
 
@@ -93,11 +100,9 @@ RUN curl -fsSL https://claude.ai/install.sh | bash -s ${CLAUDE_CODE_VERSION}
 ENV PATH="/root/.local/bin:$PATH"
 
 # ---- Build latest V8 d8 variants ----
-ARG V8_REF=origin/main
 ARG NINJA_JOBS
 
 RUN set -eux; \
-    git fetch origin main; \
     git checkout --detach "$V8_REF"; \
     rm -rf "$SRC/.cipd"; \
     gclient sync -D

--- a/harness/README.md
+++ b/harness/README.md
@@ -241,8 +241,12 @@ latest-kernel checkout/tooling layers across leaves:
 
 ```bash
 python projects/linux/build_images.py --mode base
-python projects/linux/build_images.py --mode latest --linux-ref origin/master -j 4
+python projects/linux/build_images.py --mode latest -j 4
 ```
+
+The default latest snapshot is pinned to Linux commit
+`d2c9a99135da931377240942d44f3dea104cedb8`. Pass `--linux-ref` only when
+intentionally building a different snapshot.
 
 Useful flags for large benchmark sweeps:
 

--- a/projects/linux/build_images.py
+++ b/projects/linux/build_images.py
@@ -43,6 +43,7 @@ from rich.text import Text
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LINUX_DIR = Path(__file__).resolve().parent
 BASE_DIR = REPO_ROOT / "base" / "linux"
+DEFAULT_LINUX_REF = "d2c9a99135da931377240942d44f3dea104cedb8"
 
 IMAGE_REPOS = {
     "base": "hwiwonlee/linux.base",
@@ -306,8 +307,8 @@ def main() -> int:
     )
     parser.add_argument(
         "--linux-ref",
-        default="origin/master",
-        help="Git ref for latest images (default: origin/master).",
+        default=DEFAULT_LINUX_REF,
+        help=f"Git ref for latest images (default: {DEFAULT_LINUX_REF}).",
     )
     parser.add_argument(
         "--no-cache",

--- a/projects/linux/build_images.py
+++ b/projects/linux/build_images.py
@@ -88,6 +88,7 @@ def discover_instances() -> list[str]:
 def build_image(
     tag: str,
     context: Path,
+    platform: str,
     dockerfile: Path | None = None,
     build_args: dict[str, str] | None = None,
     no_cache: bool = False,
@@ -106,7 +107,7 @@ def build_image(
                 log_file.write_text(f"SKIPPED existing {tag}\n")
             return tag, True, 0.0
 
-    cmd = ["docker", "build", "-t", tag]
+    cmd = ["docker", "build", "--platform", platform, "-t", tag]
     if dockerfile:
         cmd += ["-f", str(dockerfile)]
     if no_cache:
@@ -155,6 +156,7 @@ def build_base(
     tag, ok, elapsed = build_image(
         tag=tag,
         context=REPO_ROOT,
+        platform=args.platform,
         dockerfile=BASE_DIR / "Dockerfile",
         build_args=build_args,
         no_cache=args.no_cache,
@@ -215,6 +217,7 @@ def build_instances_parallel(
         _, ok, elapsed = build_image(
             tag=tag,
             context=cve_dir,
+            platform=args.platform,
             dockerfile=dockerfile,
             build_args=build_args,
             no_cache=args.no_cache,
@@ -311,6 +314,11 @@ def main() -> int:
         help=f"Git ref for latest images (default: {DEFAULT_LINUX_REF}).",
     )
     parser.add_argument(
+        "--platform",
+        default="linux/amd64",
+        help="Docker target platform (default: linux/amd64).",
+    )
+    parser.add_argument(
         "--no-cache",
         action="store_true",
         help="Pass --no-cache to docker build.",
@@ -358,6 +366,7 @@ def main() -> int:
         log(f"instances: {len(instances)}", progress)
         log(f"modes: {', '.join(modes)}", progress)
         log(f"parallel: {args.parallel}", progress)
+        log(f"platform: {args.platform}", progress)
         if args.kbuild_jobs:
             log(f"kbuild jobs: {args.kbuild_jobs}", progress)
         log(f"logs: {log_dir}", progress)
@@ -366,6 +375,9 @@ def main() -> int:
             if mode == "base":
                 if not build_base(args, log_dir, progress):
                     all_failed["base"] = ["linux.base"]
+                    if len(modes) > 1:
+                        log("base failed; skipping dependent image builds", progress)
+                        return
                 continue
 
             eligible = filter_instances(instances, mode)


### PR DESCRIPTION
## Summary

- Pin V8, SpiderMonkey, Linux, and `depot_tools` source revisions for reproducible builds.
- Bootstrap pinned `depot_tools` before invoking V8 tooling.
- Explicitly configure SpiderMonkey latest builds for the x86-64 target.
- Correct Linux ref resolution for branches, tags, and commit SHAs.
- Make Linux build orchestration Bash 3.2 compatible, platform-aware, and fail fast when the base image fails.